### PR TITLE
Return presumed user attributes with identity token

### DIFF
--- a/src/backend/iap/index.ts
+++ b/src/backend/iap/index.ts
@@ -7,7 +7,7 @@ import { IAPToken } from '../../types';
  * API routes for iap methods.
  */
 export enum IapRoutes {
-  GET_PRODUCT_BY_SKU = '/v1/iap/provider/getProductBySku',
+  GET_PRODUCT_BY_SKU = '/v1/iap/consumer/getProductBySku',
   RESOLVE_RECEIPTS = '/v1/iap/consumer/resolveReceipts',
   RESOLVE_RECEIPT_BY_ID = '/v1/iap/consumer/resolveReceiptById',
   RESOLVE_RECEIPTS_BY_SKU = '/v1/iap/consumer/resolveReceiptsBySku',
@@ -158,7 +158,7 @@ export class IAP extends Base {
    * ```
    */
   public async loadProduct(sku: string) {
-    const { data: { product } } = await axios.get(`${this.rootPath}${IapRoutes.GET_PRODUCT_BY_SKU}?appId=${this.projectId}&sku=${sku}`, { headers: this.rootHeaders });
+    const { data: { product } } = await axios.get(`${this.rootPath}${IapRoutes.GET_PRODUCT_BY_SKU}?sku=${sku}`, { headers: this.rootHeaders });
 
     return product;
   }

--- a/src/frontend/identity/index.ts
+++ b/src/frontend/identity/index.ts
@@ -14,6 +14,11 @@ export type AuthGrantCapability =
 export interface IdentityResult {
   token: UserToken;
   presumedRole: 'admin'|'user'|'unknown';
+  presumedAttributes: {
+    pushNotificationsEnabled: boolean;
+    username?: string;
+    profilePicture?: string;
+  }
 }
 
 /**
@@ -30,7 +35,11 @@ export class Identity extends KojiBridge {
    */
   @client
   public async getToken(): Promise<IdentityResult> {
-    const { userToken, presumedRole } = await this.sendMessageAndAwaitResponse({
+    const {
+      userToken,
+      presumedRole,
+      presumedAttributes,
+    } = await this.sendMessageAndAwaitResponse({
       kojiEventName: '@@koji/auth/getToken',
       data: {
         grants: [],
@@ -41,6 +50,7 @@ export class Identity extends KojiBridge {
     return {
       token: userToken,
       presumedRole,
+      presumedAttributes,
     };
   }
 

--- a/src/frontend/identity/index.ts
+++ b/src/frontend/identity/index.ts
@@ -15,7 +15,6 @@ export interface IdentityResult {
   token: UserToken;
   presumedRole: 'admin'|'user'|'unknown';
   presumedAttributes: {
-    pushNotificationsEnabled: boolean;
     username?: string;
     profilePicture?: string;
   }


### PR DESCRIPTION
- If the user has granted `username` to the Koji, `identity.getToken()` will return an object containing the user's username and profile picture URL.
- Fix a route for loading product information on a backend