### PR TITLE
Minor params

### DIFF
--- a/src/frontend/ui/navigate/index.ts
+++ b/src/frontend/ui/navigate/index.ts
@@ -79,13 +79,29 @@ export class Navigate extends KojiBridge {
   }
 
   /**
-   * Programmatically open the Koji's share sheet/dialog.
+   * Programmatically open the Koji's share sheet/dialog. If you do not pass any arguments, the share prompt will load for the URL of the current Koji. Pass a URL, or a relative URL, to open a share prompt for a different URL or for a deep link into your Koji.
+   *
+   * @param url An optional URL to use instead of the current Koji.
+   * @example
+   * ```javascript
+   * Koji.ui.navigate.share();
+   * ```
+   * @example
+   * ```javascript
+   * Koji.ui.navigate.share('https://withkoji.com/@sean');
+   * ```
+   * @example
+   * ```javascript
+   * Koji.ui.navigate.share('?key=value');
+   * ```
    */
   @client
-  public openShareDialog(): void {
+  public openShareDialog(url?: string): void {
     this.sendMessage({
       kojiEventName: 'Koji.Share',
-      data: {},
+      data: {
+        url,
+      },
     });
   }
 }

--- a/src/frontend/ui/upload/index.ts
+++ b/src/frontend/ui/upload/index.ts
@@ -12,6 +12,8 @@ export interface UploadOptions {
   /** Options for uploaded video */
   videoOptions?: {
     hls: boolean;
+    /** Video files constructed from getUserMedia MediaStreams will not contain correct duration headers, and need to be remuxed by Koji before they are delivered. */
+    remux: boolean;
   };
 }
 


### PR DESCRIPTION
- Adds `remux` parameter to passthrough uploads to support video files constructed from MediaStreams
- Adds optional `url` parameter to share sheet presentation, allowing for deep links