### PR TITLE
Programmatic IAP refunds, System Alerts, Chrome Visibility

### DIFF
--- a/src/backend/iap/index.ts
+++ b/src/backend/iap/index.ts
@@ -13,6 +13,7 @@ export enum IapRoutes {
   RESOLVE_RECEIPTS_BY_SKU = '/v1/iap/consumer/resolveReceiptsBySku',
   UPDATE_RECEIPT = '/v1/iap/consumer/updateReceiptAttributes',
   CAPTURE_TRANSACTION = '/v1/iap/consumer/captureTransaction',
+  REFUND_TRANSACTION = '/v1/iap/consumer/refundTransaction',
 }
 
 /**
@@ -261,6 +262,27 @@ export class IAP extends Base {
   public async captureTransaction(receiptId: string): Promise<void> {
     await axios.post(
       `${this.rootPath}${IapRoutes.CAPTURE_TRANSACTION}`,
+      {
+        receiptId,
+      },
+      { headers: this.rootHeaders },
+    );
+  }
+
+  /**
+   * Programmatically refund a transaction by its receipt ID. Only unsettled
+   * transactions can be refunded.
+   *
+   * @param receiptId Receipt ID
+   *
+   * @example
+   * ```javascript
+   * iap.refundTransaction(receiptId);
+   * ```
+   */
+  public async refundTransaction(receiptId: string): Promise<void> {
+    await axios.post(
+      `${this.rootPath}${IapRoutes.REFUND_TRANSACTION}`,
       {
         receiptId,
       },

--- a/src/backend/iap/index.ts
+++ b/src/backend/iap/index.ts
@@ -193,7 +193,11 @@ export class IAP extends Base {
    */
   @server
   public async resolveReceiptById(receiptId: string): Promise<IapReceipt> {
-    const { data: { receipt } } = await axios.post(`${this.rootPath}${IapRoutes.RESOLVE_RECEIPT_BY_ID}`, { receiptId }, { headers: this.rootHeaders });
+    const { data: { receipt } } = await axios.post(
+      `${this.rootPath}${IapRoutes.RESOLVE_RECEIPT_BY_ID}`,
+      { receiptId },
+      { headers: this.rootHeaders },
+    );
 
     return receipt;
   }
@@ -211,7 +215,11 @@ export class IAP extends Base {
    */
   @server
   public async resolveReceiptsBySku(sku: string): Promise<IapReceipt[]> {
-    const { data: { receipts } } = await axios.post(`${this.rootPath}${IapRoutes.RESOLVE_RECEIPTS_BY_SKU}`, { sku }, { headers: this.rootHeaders });
+    const { data: { receipts } } = await axios.post(
+      `${this.rootPath}${IapRoutes.RESOLVE_RECEIPTS_BY_SKU}`,
+      { sku },
+      { headers: this.rootHeaders },
+    );
 
     return receipts;
   }
@@ -231,7 +239,11 @@ export class IAP extends Base {
    * iap.updateReceipt(id, { consumed: true }, 'You have successfully redeemed your credit.');
    * ```
    */
-  public async updateReceipt(receiptId: string, attributes: { [index: string]: any }, notificationMessage?: string): Promise<any> {
+  public async updateReceipt(
+    receiptId: string,
+    attributes: { [index: string]: any },
+    notificationMessage?: string,
+  ): Promise<any> {
     const { data } = await axios.post(
       `${this.rootPath}${IapRoutes.UPDATE_RECEIPT}`,
       {
@@ -305,7 +317,10 @@ export class IAP extends Base {
    * ```
    */
   public async loadProduct(sku: string): Promise<IapProduct> {
-    const { data: { product } } = await axios.get(`${this.rootPath}${IapRoutes.GET_PRODUCT_BY_SKU}?sku=${sku}`, { headers: this.rootHeaders });
+    const { data: { product } } = await axios.get(
+      `${this.rootPath}${IapRoutes.GET_PRODUCT_BY_SKU}?sku=${sku}`,
+      { headers: this.rootHeaders },
+    );
 
     return product;
   }

--- a/src/backend/iap/index.ts
+++ b/src/backend/iap/index.ts
@@ -43,6 +43,8 @@ export interface IapReceipt {
   };
   /** Date of the purchase. */
   datePurchased: Date;
+  /** If the transaction has been refunded, either manually or due to capture expiry, this key contains the date of that refund. */
+  dateRefunded?: Date;
 }
 
 /**

--- a/src/frontend/playerState/index.ts
+++ b/src/frontend/playerState/index.ts
@@ -80,6 +80,8 @@ export class PlayerState extends KojiBridge {
   public hasFocus: boolean = false;
   /** Presentation style of the Koji. */
   public presentationStyle: PlayerPresentationStyle = 'fullscreen';
+  /** Whether the player chrome is visible */
+  public isChromeVisible: boolean = false;
 
   public constructor() {
     super();
@@ -109,6 +111,10 @@ export class PlayerState extends KojiBridge {
 
     // Set the initial value based on the feed hash
     this.hasFocus = !window.location.hash.includes('#koji-feed-key=');
+
+    if (this.presentationStyle === 'fullscreen') {
+      this.isChromeVisible = true;
+    }
   }
 
   /**
@@ -155,6 +161,34 @@ export class PlayerState extends KojiBridge {
     return this.execCallbackOnMessage(() => {
       callback();
     }, 'KojiFeed.Pause');
+  }
+
+  /**
+   * Hide any platform chrome, like the Koji button or the current user's
+   * notification/profile icon. Incorrectly controlling player chrome can result
+   * in a disorienting user experience, so this functionality should be used
+   * judiciously. Koji chrome must be displayed on all Root screens in a
+   * template, and can be hidden if a user navigates to a deeper screen inside
+   * the template.
+   */
+  @client
+  public hideChrome() {
+    this.sendMessage({
+      kojiEventName: 'Koji.Player.HideChrome',
+      data: {},
+    });
+    this.isChromeVisible = false;
+  }
+
+  /**
+   * If platform chrome has been hidden, restore it.
+   */
+  public showChrome() {
+    this.sendMessage({
+      kojiEventName: 'Koji.Player.ShowChrome',
+      data: {},
+    });
+    this.isChromeVisible = true;
   }
 
   /**

--- a/src/frontend/ui/present/index.ts
+++ b/src/frontend/ui/present/index.ts
@@ -25,7 +25,7 @@ export interface PresentAlertOptions {
   message: string;
 }
 
-export type SystemAlertType = 'success'|'sent'|'reported';
+export type SystemAlertType = 'success'|'sent'|'reported'|'rejected';
 
 /**
  * Presents dialog boxes to users on the frontend of your Koji.

--- a/src/frontend/ui/present/index.ts
+++ b/src/frontend/ui/present/index.ts
@@ -25,6 +25,8 @@ export interface PresentAlertOptions {
   message: string;
 }
 
+export type SystemAlertType = 'success'|'sent'|'reported';
+
 /**
  * Presents dialog boxes to users on the frontend of your Koji.
  */
@@ -83,6 +85,25 @@ export class Present extends KojiBridge {
         data: {
           title: options.title,
           message: options.message,
+        },
+      },
+    );
+  }
+
+  /**
+   * Present a system alert (icon + label). System alerts appear for 1200ms and
+   * then dismiss, allowing for an easy way to communicate state changes to a
+   * user.
+   *
+   * @param type The type of system alert to display.
+   */
+  @client
+  public systemAlert(type: SystemAlertType) {
+    this.sendMessage(
+      {
+        kojiEventName: 'Koji.ShowSystemAlert',
+        data: {
+          type,
         },
       },
     );


### PR DESCRIPTION
## Backend/IAP
- Introduce support for `refundTransaction(receiptId)`, allowing a template backend to programmatically refund an unsettled transaction (e.g., an admin fulfillment dashboard in the template might want to support its own "Refund Order" button, rather than requiring the admin to open a receipt in their wallet to trigger a refund)

## Frontend/PlayerState
- The `hideChrome()` and `showChrome()` methods allow a template to programmatically hide and show Koji Platform player chrome (the Koji button). Player chrome must always be visible from the template's root, but can be hidden in multi-screen experiences when a user enters a nested screen.
- The `isChromeVisible` property lets a template query whether player chrome is showing. Player chrome is hidden by default when the Koji's `presentationStyle` is `popover`.

## Frontend/UI
- The `systemAlert(type)` method on `ui.present` shows notifications to help a user understand a change in state. Today, the only supported system alert types are `success` (check mark), `sent` (message sent icon), `rejected` (alert icon), and `reported` (alert icon). Proposals for more types are welcome.
- Using `share()` to present a deep link will now create a koji.to short URL for your application's deep link.

---
internal:
https://github.com/madewithkoji/koji-frontend/pull/1113
https://github.com/madewithkoji/koji-api/pull/605 