### PR TITLE
Fix url navigation breaking platform communication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@withkoji/core",
-  "version": "0.0.17",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withkoji/core",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Core library for developing remixable Koji templates",
   "main": "dist/index.js",
   "scripts": {

--- a/src/frontend/index.ts
+++ b/src/frontend/index.ts
@@ -91,6 +91,16 @@ export class Koji {
 
   constructor() {
     this.isReady = false;
+
+    // Pull the `koji-feed-key` off the URL fragment, if it exists, and save it
+    // to the window so we can grab it if the URL changes due to navigation
+    // events.
+    if (!window.KOJI_FEED_KEY) {
+      const feedKey = window.location.hash.replace('#koji-feed-key=', '');
+      if (feedKey) {
+        window.KOJI_FEED_KEY = feedKey;
+      }
+    }
   }
 
   /**
@@ -246,7 +256,7 @@ export class Koji {
           window.parent.postMessage(
             {
               _type: 'Koji.ClickEvent',
-              _feedKey: window.location.hash.replace('#koji-feed-key=', ''),
+              _feedKey: window.KOJI_FEED_KEY,
               x: clientX,
               y: clientY,
             },
@@ -344,7 +354,7 @@ export class Koji {
     window.parent.postMessage(
       {
         _type: 'KojiPreview.Ready',
-        _feedKey: window.location.hash.replace('#koji-feed-key=', ''),
+        _feedKey: window.KOJI_FEED_KEY,
       },
       '*',
     );

--- a/src/frontend/kojiBridge/index.ts
+++ b/src/frontend/kojiBridge/index.ts
@@ -49,7 +49,7 @@ export class KojiBridge {
       {
         _kojiEventName: postMessage.kojiEventName,
         _type: postMessage.kojiEventName,
-        _feedKey: window.location.hash.replace('#koji-feed-key=', ''),
+        _feedKey: window.KOJI_FEED_KEY,
         ...postMessage.data,
       },
       '*',
@@ -78,7 +78,7 @@ export class KojiBridge {
         {
           _kojiEventName: postMessage.kojiEventName,
           _type: postMessage.kojiEventName,
-          _feedKey: window.location.hash.replace('#koji-feed-key=', ''),
+          _feedKey: window.KOJI_FEED_KEY,
           _idempotencyKey: idempotencyKey,
           ...postMessage.data,
         },

--- a/src/frontend/playerState/index.ts
+++ b/src/frontend/playerState/index.ts
@@ -110,7 +110,7 @@ export class PlayerState extends KojiBridge {
     }
 
     // Set the initial value based on the feed hash
-    this.hasFocus = !window.location.hash.includes('#koji-feed-key=');
+    this.hasFocus = !window.KOJI_FEED_KEY;
 
     if (this.presentationStyle === 'fullscreen') {
       this.isChromeVisible = true;

--- a/src/frontend/remix/index.ts
+++ b/src/frontend/remix/index.ts
@@ -7,6 +7,8 @@ declare global {
   interface Window {
     /** Enables Koji's proxy server to write remix-specific values to the KOJI_OVERRIDES property. */
     KOJI_OVERRIDES: any;
+    /** Private reference to the Koji Feed Key, which is saved in a URL fragment when the Koji first loads */
+    KOJI_FEED_KEY?: string;
   }
 }
 


### PR DESCRIPTION
The `koji-feed-key` is a value present in the URL fragment when the app is loaded by the platform. The value of this parameter is included with each message, which allows the platform to keep track of the app sending the message in the case that there are multiple apps visible on a single page.

However, because this value is included in a fragment, actions inside the app that change the URL (like navigation) clear the hash and break messaging. This hotfix resolves this issue by modifying the behavior of the package so that it pulls and stores the fragment on initial load, and includes that stored value with each request, rather than the value present in the URL fragment.